### PR TITLE
Irods import improve

### DIFF
--- a/modules/VRPipe/Steps/irods.pm
+++ b/modules/VRPipe/Steps/irods.pm
@@ -107,7 +107,7 @@ class VRPipe::Steps::irods with VRPipe::StepRole {
         my $expected_md5 = $dest_file->metadata->{expected_md5} || $irodschksum;
         unless ($irodschksum eq $expected_md5) {
             $dest_file->unlink;
-            $self->throw("expected md5 checksum in metadata did not match md5 of file in IRODS; aborted");
+            $self->throw("expected md5 checksum in metadata did not match md5 of $source in IRODS; aborted");
         }
         
         # -K: checksum


### PR DESCRIPTION
This fixes IRODS import so it checks the known MD5 of the file in IRODS before we try and repeatedly download it.
