### PR TITLE
Check disk stats before throwing on open

### DIFF
--- a/modules/VRPipe/File.pm
+++ b/modules/VRPipe/File.pm
@@ -275,7 +275,11 @@ class VRPipe::File extends VRPipe::Persistent {
         $self->throw("Only modes <, > and >> are supported") unless $mode =~ /^(?:<|>)+$/;
         
         if ($mode eq '<' && !$self->e) {
-            $self->throw("File '$path' does not exist, so cannot be opened for reading");
+            $self->update_stats_from_disc;
+            # give it a second chance...
+            if (!$self->e) {
+                $self->throw("File '$path' does not exist, so cannot be opened for reading");
+            }
         }
         
         my $fh;


### PR DESCRIPTION
Quick fix to do a last-chance update_stats_from_disc when trying to open a file that has $self->e == 0.  This solves an issue where a file (here a fofn) had the wrong file permissions when the db entry was created (so had e==0), but fixing the file permissions did not fix the open as the database was out of sync with the file on disc.

This should have no side-effects, as the next statement would have thrown an error anyway.
