### PR TITLE
Check disk stats before throwing on open

### DIFF
--- a/modules/VRPipe/File.pm
+++ b/modules/VRPipe/File.pm
@@ -275,7 +275,11 @@ class VRPipe::File extends VRPipe::Persistent {
         $self->throw("Only modes <, > and >> are supported") unless $mode =~ /^(?:<|>)+$/;
         
         if ($mode eq '<' && !$self->e) {
-            $self->throw("File '$path' does not exist, so cannot be opened for reading");
+            $self->update_stats_from_disc;
+            # give it a second chance...
+            if (!$self->e) {
+                $self->throw("File '$path' does not exist, so cannot be opened for reading");
+            }
         }
         
         my $fh;


### PR DESCRIPTION
Sorry, wrong destination branch last time.
Small fix to make a last-minute update_stats_from_disc in File::open where the file has self->e == 0.  This solves an issue where a file (here a fofn) had the wrong file permissions when the File object was stored in the db (hence had e == 0).  Fixing the file permissions didn't help as the db was out of sync with the file on disc.  Adding this update_stats_from_disc call allows code that was going to throw anyway to check if the file is now available/readable.
